### PR TITLE
Fix GitHub actions tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Create database
       run: |
         scripts/setup_config.sh nemanode root password | mysql --host 127.0.0.1 --port 3306 -uroot -ppassword
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
     - name: Install dependencies
       run: |
         npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
     - name: Verify MySQL connection from host
       run: |
-        sudo apt-get install -y mysql-client
         mysql --host 127.0.0.1 --port 3306 -uroot -ppassword -e "SHOW DATABASES"
     - uses: actions/checkout@v2
     - name: Create database

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:5.7
+        image: mariadb:10.3
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+ssh://git@github.com:dwitvliet/NemaNode.git"
   },
   "engines": {
-    "node": ">=11.15.0",
+    "node": ">=11.15.0 <16.0.0",
     "npm": ">=6.7.0"
   },
   "browserslist": "> 0.1%, last 5 versions, not dead",

--- a/src/server/populate-db/populate-connections.js
+++ b/src/server/populate-db/populate-connections.js
@@ -27,8 +27,9 @@ let populateConnections = async (dbConn, connectionsJSON) => {
   let connectionCounter = 0;
   connectionsJSON.forEach(connection => {
     let { datasetId, pre, post, typ, syn, ids, pre_tid, post_tid } = connection;
-    
-    switch(typ) {
+   
+    let type;
+    switch (typ) {
       case 0:
         type = 'chemical';
         break;


### PR DESCRIPTION
There are four main changes made:

* Remove installation of `mysql-client` - the package is already installed on the images used by GitHub Actions, attempting to reinstall fails
* Use Node v14 - the older version of the `node-sass` package that is specified in `package.json` is not compatible with Node v16
* Fix some linting errors in `populate-connections.js` - some spacing issues and not initializing a variable.
* Use MariaDB 10.3 as the MySQL server version since that is what we are using in production

This PR gets the tests running again with minimal changes, but does not deal with old, unsupported dependencies.