### PR TITLE
Dataset marker tweak

### DIFF
--- a/src/client/scss/sidebars.scss
+++ b/src/client/scss/sidebars.scss
@@ -278,9 +278,9 @@ $sidenav-padding: 16px;
 
   /* Dataset bookmarks */
   $bookmark-top-margin: 40px;
-  $bookmark-height: 20px;
-  $bookmark-width: 20px;
-  $triangle-height: 13px;
+  $bookmark-height: 12px;
+  $bookmark-width: 12px;
+  $triangle-height: 8px;
   $dataset-tooltip-height: 76px;
   $dataset-tooltip-width: 150px;
   $dataset-tooltip-padding: 8px;

--- a/src/server/populate-db/raw-data/datasets.json
+++ b/src/server/populate-db/raw-data/datasets.json
@@ -4,7 +4,7 @@
       "name":"Liefer et al., 2021, Dataset 0 (L1)",
       "type":"head",
       "time":50,
-      "visualTime":50,
+      "visualTime":51.5,
       "description":"Mock functional data for Liefer lab, 2021"
    },
    {


### PR DESCRIPTION
## Summary Change Description

Squeezed in the mock data in the bookmark dataset plot by making the markers smaller and adjusting the visualTime position.

## Affected Issue Numbers

- Resolves #9

## Review Notes

To see the change, you have to run:

```
npm run populate-database
npm run watch
```

<img width="316" alt="markertweak1" src="https://user-images.githubusercontent.com/2300532/158475224-a1e55e32-9758-4974-8cb0-d9f279c4d804.png">
<img width="154" alt="markertweak2" src="https://user-images.githubusercontent.com/2300532/158475248-fb96c691-c099-4ce5-bd8c-0be57c8f6297.png">

Note, it's a mostly static and finnicky design.  At one point, I'd set `visualTime` to 48 and I could see the bottom of the "marker" between and behind 2 other markers, but it was not clickable.  I spent a little time trying to see if I could control the order in which they were drawn so that markers would "leaf together", but I couldn't figure that out.  I figured out how to make the markers thinner, which made them look a bit weird, so then I shortened them as well by the same percentage.

There really should be a different mechanism to select datasets, like a multiple select list or something, because this is just not going to scale well.