### PR TITLE
Unbowing on hover fix

### DIFF
--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -356,7 +356,14 @@ let cystyle = {
       }
     },
     {
-      selector: 'edge.besideGj',
+      selector: 'edge.besideNeighbors',
+      css: {
+        'curve-style': 'bezier',
+        'control-point-step-size': 40
+      }
+    },
+    {
+      selector: 'edge.besideGjAlone',
       css: {
         'curve-style': 'unbundled-bezier'
       }
@@ -374,6 +381,14 @@ let cystyle = {
       css: {
         'target-arrow-shape': 'tee',
         'source-arrow-shape': 'tee'
+      }
+    },
+    {
+      selector: 'edge[type = 4]:loop',
+      css: {
+        'curve-style': 'bezier',
+        'source-distance-from-node': 0,
+        'target-distance-from-node': 0
       }
     },
     {

--- a/src/client/js/view/network.js
+++ b/src/client/js/view/network.js
@@ -184,12 +184,33 @@ class GraphView extends View2 {
       cy.add(Object.values(newEdges));
 
       cy.startBatch();
+      //
       // Label edges parallel to gap junctions to prevent overlaps.
-      cy.edges().removeClass('besideGj');
+      //
+
+      // Remove all bowing (dynamic: besideNeighbors and static: besideGjAlone)
+      cy.edges().removeClass('besideNeighbors');
+      cy.edges().removeClass('besideGjAlone');
+      // Start out by assuming every line has a neighbor (and dynamically & concentrically bow everything)
+      cy.edges().addClass('besideNeighbors');
+      // Remove bowing from all gap junctions
+      cy.edges('[type = 2]').removeClass('besideNeighbors');
+      // Get gap junctions that have a neighbor of 1 type (functional connections) and remove the bezier bowing and add
+      // a static bowing (unbundled-bezier)
       cy.edges('[type = 2]')
         .parallelEdges()
         .filter('[type != 2]')
-        .addClass('besideGj');
+        .filter('[type != 0]')
+        .removeClass('besideNeighbors')
+        .addClass('besideGjAlone');
+      // Get gap junctions that have a neighbor of 1 type (chemical synapse) and remove the bezier bowing and add a
+      // static bowing (unbundled-bezier)
+      cy.edges('[type = 2]')
+        .parallelEdges()
+        .filter('[type != 2]')
+        .filter('[type != 4]')
+        .removeClass('besideNeighbors')
+        .addClass('besideGjAlone');
 
       // Label nodes connected with gap junctions in order to efficiently update gap junction edges
       // that are stretched/shrinked as the node moves.


### PR DESCRIPTION
I can't say that I understand this at a deep level, but I believe it works and my (possibly "Neils Bohr") model of the logic of the [bezier](https://js.cytoscape.org/#style/bezier-edges) and [unbundled-bezier](https://js.cytoscape.org/#style/unbundled-bezier-edges) is explained in the comments.  The style used in the selectors is explained in the links I linked to each type.

There could be an entirely better solution to this, but it took me all afternoon/evening to get something that worked in my test cases (AIY and AVA - each with all the thresholds at 1).  So please try it out with other cell searches and see if it holds up.