### PR TITLE
Overlap issue

### DIFF
--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -299,7 +299,7 @@ let cystyle = {
         'line-color': cytoscapeColors.coloursEdge['typ0'],
         'target-arrow-color': cytoscapeColors.coloursEdge['typ0'],
         color: 'black',
-        'control-point-step-size': 40,
+        'control-point-step-size': 20,
 
         'text-outline-width': 2,
         'text-outline-color': cytoscapeColors.backgroundColor,
@@ -330,7 +330,7 @@ let cystyle = {
         'target-arrow-color': cytoscapeColors.coloursEdge['typ4'],
         'source-arrow-color': cytoscapeColors.coloursEdge['typ4'],
         color: 'black',
-        'control-point-step-size': 40,
+        'control-point-step-size': 20,
 
         'text-outline-width': 2,
         'text-outline-color': cytoscapeColors.backgroundColor,

--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -377,8 +377,10 @@ let cystyle = {
     {
       selector: 'edge.evenNonGjWhenOddNonGjWithGj',
       css: {
-        'curve-style': 'bezier',
-        'control-point-step-size': 50
+        // 'curve-style': 'bezier',
+        // 'control-point-step-size': 50
+        'curve-style': 'unbundled-bezier',
+        'control-point-distances': '40 -40 80 -80'
       }
     },
     // {
@@ -392,7 +394,7 @@ let cystyle = {
       selector: 'edge.oddNonGjWhenOddNonGjWithGj',
       css: {
         'curve-style': 'unbundled-bezier',
-        'control-point-distances': '-40'
+        'control-point-distances': '80'
       }
     },
     // {

--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -380,7 +380,7 @@ let cystyle = {
         // 'curve-style': 'bezier',
         // 'control-point-step-size': 50
         'curve-style': 'unbundled-bezier',
-        'control-point-distances': '40 -40 80 -80'
+        'control-point-distances': '25 -25'
       }
     },
     // {
@@ -394,7 +394,7 @@ let cystyle = {
       selector: 'edge.oddNonGjWhenOddNonGjWithGj',
       css: {
         'curve-style': 'unbundled-bezier',
-        'control-point-distances': '80'
+        'control-point-distances': '50 -50'
       }
     },
     // {

--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -366,13 +366,6 @@ let cystyle = {
       }
     },
     {
-      selector: 'edge.allEvenNonGj',
-      css: {
-        'curve-style': 'bezier',
-        'control-point-step-size': '40px'
-      }
-    },
-    {
       selector: 'edge.innerTierWithGj',
       css: {
         'curve-style': 'unbundled-bezier',

--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -356,7 +356,14 @@ let cystyle = {
       }
     },
     {
-      selector: 'edge.besideGj',
+      selector: 'edge.besideNeighbors',
+      css: {
+        'curve-style': 'bezier',
+        'control-point-step-size': 40
+      }
+    },
+    {
+      selector: 'edge.besideGjAlone',
       css: {
         'curve-style': 'unbundled-bezier'
       }
@@ -374,6 +381,14 @@ let cystyle = {
       css: {
         'target-arrow-shape': 'tee',
         'source-arrow-shape': 'tee'
+      }
+    },
+    {
+      selector: 'edge[type = 4]:loop',
+      css: {
+        'curve-style': 'bezier',
+        'source-distance-from-node': 0,
+        'target-distance-from-node': 0
       }
     },
     {

--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -299,6 +299,8 @@ let cystyle = {
         'line-color': cytoscapeColors.coloursEdge['typ0'],
         'target-arrow-color': cytoscapeColors.coloursEdge['typ0'],
         color: 'black',
+        // 'control-point-distances': '-20 20',
+        'control-point-step-size': 40,
 
         'text-outline-width': 2,
         'text-outline-color': cytoscapeColors.backgroundColor,
@@ -320,12 +322,22 @@ let cystyle = {
     {
       selector: 'edge[type = 4]',
       css: {
-        'curve-style': 'segments',
+        width: 'data(width)',
+        'font-size': '18px',
+        'z-index': 5,
+        'curve-style': 'bezier',
         'target-arrow-shape': 'triangle',
         'line-color': cytoscapeColors.coloursEdge['typ4'],
         'target-arrow-color': cytoscapeColors.coloursEdge['typ4'],
         'source-arrow-color': cytoscapeColors.coloursEdge['typ4'],
-        'segment-distances': '0 -8 8 -8 8 0'
+        color: 'black',
+        // 'control-point-distances': '-40 40',
+        'control-point-step-size': 40,
+
+        'text-outline-width': 2,
+        'text-outline-color': cytoscapeColors.backgroundColor,
+        'source-distance-from-node': 10,
+        'target-distance-from-node': 10
       }
     },
     {
@@ -356,18 +368,40 @@ let cystyle = {
       }
     },
     {
-      selector: 'edge.besideNeighbors',
+      selector: 'edge.allEvenNonGj',
       css: {
         'curve-style': 'bezier',
-        'control-point-step-size': 40
+        'control-point-step-size': '40px'
       }
     },
     {
-      selector: 'edge.besideGjAlone',
+      selector: 'edge.evenNonGjWhenOddNonGjWithGj',
       css: {
-        'curve-style': 'unbundled-bezier'
+        'curve-style': 'bezier',
+        'control-point-step-size': 50
       }
     },
+    // {
+    //   selector: 'edge.evenNonGjWhenOddNonGjWithOutGj',
+    //   css: {
+    //     'curve-style': 'bezier',
+    //     'control-point-step-size': '40px'
+    //   }
+    // },
+    {
+      selector: 'edge.oddNonGjWhenOddNonGjWithGj',
+      css: {
+        'curve-style': 'unbundled-bezier',
+        'control-point-distances': '-40'
+      }
+    },
+    // {
+    //   selector: 'edge.oddNonGjWhenOddNonGjWithOutGj',
+    //   css: {
+    //     'curve-style': 'bezier',
+    //     'control-point-step-size': '40px'
+    //   }
+    // },
     {
       selector: 'edge:loop',
       css: {

--- a/src/client/js/view/network-style.js
+++ b/src/client/js/view/network-style.js
@@ -299,7 +299,6 @@ let cystyle = {
         'line-color': cytoscapeColors.coloursEdge['typ0'],
         'target-arrow-color': cytoscapeColors.coloursEdge['typ0'],
         color: 'black',
-        // 'control-point-distances': '-20 20',
         'control-point-step-size': 40,
 
         'text-outline-width': 2,
@@ -331,7 +330,6 @@ let cystyle = {
         'target-arrow-color': cytoscapeColors.coloursEdge['typ4'],
         'source-arrow-color': cytoscapeColors.coloursEdge['typ4'],
         color: 'black',
-        // 'control-point-distances': '-40 40',
         'control-point-step-size': 40,
 
         'text-outline-width': 2,
@@ -375,35 +373,19 @@ let cystyle = {
       }
     },
     {
-      selector: 'edge.evenNonGjWhenOddNonGjWithGj',
+      selector: 'edge.innerTierWithGj',
       css: {
-        // 'curve-style': 'bezier',
-        // 'control-point-step-size': 50
         'curve-style': 'unbundled-bezier',
         'control-point-distances': '25 -25'
       }
     },
-    // {
-    //   selector: 'edge.evenNonGjWhenOddNonGjWithOutGj',
-    //   css: {
-    //     'curve-style': 'bezier',
-    //     'control-point-step-size': '40px'
-    //   }
-    // },
     {
-      selector: 'edge.oddNonGjWhenOddNonGjWithGj',
+      selector: 'edge.outerTierWithGj',
       css: {
         'curve-style': 'unbundled-bezier',
         'control-point-distances': '50 -50'
       }
     },
-    // {
-    //   selector: 'edge.oddNonGjWhenOddNonGjWithOutGj',
-    //   css: {
-    //     'curve-style': 'bezier',
-    //     'control-point-step-size': '40px'
-    //   }
-    // },
     {
       selector: 'edge:loop',
       css: {

--- a/src/client/js/view/network.js
+++ b/src/client/js/view/network.js
@@ -193,8 +193,8 @@ class GraphView extends View2 {
       cy.edges().removeClass('innerTierWithGj');
       cy.edges().removeClass('outerTierWithGj');
 
-      // When there is a gap junction, make the inner tier be populated with the majority type (synapse + functional),
-      // or synapses if full
+      // When there is a gap junction, make the inner tier be populated with the majority type
+      // (synapse + functional), or synapses if full
       cy.edges('[type = 2]')
         .parallelEdges()
         .not(':loop')
@@ -203,11 +203,11 @@ class GraphView extends View2 {
           let numfc = 0;
           let numcs = 0;
           let tot = 0;
-          let nbrs = ele.parallelEdges()
+          let nbrs = ele.parallelEdges();
           for (let i = 0; i < nbrs.size(); i++) {
             if (nbrs[i].data('type') === 0) {
               numcs += 1;
-              tot+= 1;
+              tot += 1;
             } else if (nbrs[i].data('type') === 4) {
               numfc += 1;
               tot += 1;
@@ -224,10 +224,10 @@ class GraphView extends View2 {
           }
           return false;
         })
-        .addClass('innerTierWithGj')
+        .addClass('innerTierWithGj');
 
-      // When there is a gap junction, make the outer tier be populated with the minority type (synapse + functional),
-      // or functional connections if full
+      // When there is a gap junction, make the outer tier be populated with the minority type
+      // (synapse + functional), or functional connections if full
       cy.edges('[type = 2]')
         .parallelEdges()
         .not(':loop')
@@ -235,7 +235,7 @@ class GraphView extends View2 {
         .filter(function(ele) {
           let numfc = 0;
           let numcs = 0;
-          let nbrs = ele.parallelEdges()
+          let nbrs = ele.parallelEdges();
           for (let i = 0; i < nbrs.size(); i++) {
             if (nbrs[i].data('type') === 0) {
               numcs += 1;
@@ -252,7 +252,7 @@ class GraphView extends View2 {
           }
           return false;
         })
-        .addClass('outerTierWithGj')
+        .addClass('outerTierWithGj');
 
       // Label nodes connected with gap junctions in order to efficiently update gap junction edges
       // that are stretched/shrinked as the node moves.

--- a/src/client/js/view/network.js
+++ b/src/client/js/view/network.js
@@ -252,12 +252,15 @@ class GraphView extends View2 {
         .filter(function(ele) {
           let numfc = 0;
           let numcs = 0;
+          let tot = 0;
           let nbrs = ele.parallelEdges()
           for (let i = 0; i < nbrs.size(); i++) {
             if (nbrs[i].data('type') === 0) {
               numcs += 1;
+              tot+= 1;
             } else if (nbrs[i].data('type') === 4) {
               numfc += 1;
+              tot += 1;
             }
           }
           if (ele.data('type') == 0 && numcs == 2 && numfc == 1) {
@@ -265,6 +268,9 @@ class GraphView extends View2 {
             return true;
           } else if (ele.data('type') == 4 && numcs == 1 && numfc == 2) {
             console.log("even functional connection")
+            return true;
+          } else if (tot < 3) {
+            console.log("Fewer than 3 chemical synapses & functional connection")
             return true;
           }
           return false;

--- a/src/client/js/view/network.js
+++ b/src/client/js/view/network.js
@@ -188,29 +188,231 @@ class GraphView extends View2 {
       // Label edges parallel to gap junctions to prevent overlaps.
       //
 
+      // // Remove all bowing (dynamic: besideNeighbors and static: besideGjAlone)
+      // cy.edges().removeClass('twoChemicalBesideNeighbors');
+      // cy.edges().removeClass('twoFunctionalBesideNeighbors');
+      // cy.edges().removeClass('besideGjAlone');
+      // // Start out by assuming every functional/synaptic line has a neighbor (and bow everything)
+      // cy.edges('[type = 0]').addClass('twoChemicalBesideNeighbors');
+      // cy.edges('[type = 4]').addClass('twoFunctionalBesideNeighbors');
+      // // Get gap junctions that have a neighbor of 1 type (functional connections) and remove the bezier bowing and add
+      // // a static bowing (unbundled-bezier)
+      // cy.edges('[type = 2]')
+      //   .parallelEdges()
+      //   .filter(function(ele, i, eles) {
+      //     let numfc = 0;
+      //     let numcs = 0;
+      //     for (let i = 0; i < eles.size; i++) {
+      //       if (eles[i].data('type') === 0) {
+      //         numcs += 1;
+      //       } else if (eles[i].data('type') === 4) {
+      //         numfc += 1;
+      //       }
+      //     }
+      //     if ((numfc == 1 && numcs == 0) || (numfc == 0 && numcs == 1)) {
+      //       return true;
+      //     }
+      //     return false;
+      //   })
+      //   .removeClass('twoFunctionalBesideNeighbors')
+      //   .removeClass('twoChemicalBesideNeighbors')
+      //   .addClass('besideGjAlone');
+
       // Remove all bowing (dynamic: besideNeighbors and static: besideGjAlone)
-      cy.edges().removeClass('besideNeighbors');
-      cy.edges().removeClass('besideGjAlone');
-      // Start out by assuming every line has a neighbor (and dynamically & concentrically bow everything)
-      cy.edges().addClass('besideNeighbors');
-      // Remove bowing from all gap junctions
-      cy.edges('[type = 2]').removeClass('besideNeighbors');
-      // Get gap junctions that have a neighbor of 1 type (functional connections) and remove the bezier bowing and add
-      // a static bowing (unbundled-bezier)
+      cy.edges().removeClass('allEvenNonGj');
+      cy.edges().removeClass('evenNonGjWhenOddNonGjWithGj');
+      cy.edges().removeClass('evenNonGjWhenOddNonGjWithOutGj');
+      cy.edges().removeClass('oddNonGjWhenOddNonGjWithGj');
+      cy.edges().removeClass('oddNonGjWhenOddNonGjWithOutGj');
+      // cy.edges('[type != 2]').removeStyle('curve-style control-point-step-size')
+      // When there are an even number of non-gap junction lines, assign the allEvenNonGj selector
+      // cy.edges()
+      //   .parallelEdges()
+      //   .filter(function(ele, i, eles) {
+      //     let numlines = 0;
+      //     for (let i = 0; i < eles.size; i++) {
+      //       if (eles[i].data('type') === 0 || eles[i].data('type') === 4) {
+      //         numlines += 1;
+      //       }
+      //     }
+      //     if (numlines == 2 || numlines == 4) {
+      //       return true;
+      //     }
+      //     return false;
+      //   })
+      //   .addClass('allEvenNonGj')
+      //   .style('curve-style', 'bezier')
+      //   .style('control-point-step-size', '40px');
+
+      // When there are an even number of nonGj lines neighboring a gap junction, assign the evenNonGjWhenOddNonGjWithGj selector to the even type
       cy.edges('[type = 2]')
         .parallelEdges()
+        .not(':loop')
         .filter('[type != 2]')
-        .filter('[type != 0]')
-        .removeClass('besideNeighbors')
-        .addClass('besideGjAlone');
-      // Get gap junctions that have a neighbor of 1 type (chemical synapse) and remove the bezier bowing and add a
-      // static bowing (unbundled-bezier)
+        .filter(function(ele) {
+          let numfc = 0;
+          let numcs = 0;
+          let nbrs = ele.parallelEdges()
+          for (let i = 0; i < nbrs.size(); i++) {
+            if (nbrs[i].data('type') === 0) {
+              numcs += 1;
+            } else if (nbrs[i].data('type') === 4) {
+              numfc += 1;
+            }
+          }
+          if (ele.data('type') == 0 && numcs == 2 && numfc == 1) {
+            console.log("even synapse")
+            return true;
+          } else if (ele.data('type') == 4 && numcs == 1 && numfc == 2) {
+            console.log("even functional connection")
+            return true;
+          }
+          return false;
+        })
+        .addClass('evenNonGjWhenOddNonGjWithGj')
+      //   .style('curve-style', 'bezier')
+      //   .style('control-point-step-size', '50px');
+
+      // When there are an even number of nonGj lines not neighboring a gap junction, assign the evenNonGjWhenOddNonGjWithOutGj selector to the even type
+      // cy.edges('[type != 2]')
+      //   .parallelEdges()
+      //   .filter(function(ele, i, eles) {
+      //     let eventype = '0';
+      //     let numfc = 0;
+      //     let numcs = 0;
+      //     for (let i = 0; i < eles.size; i++) {
+      //       if (eles[i].data('type') === 0) {
+      //         numcs += 1;
+      //       } else if (eles[i].data('type') === 4) {
+      //         numfc += 1;
+      //       }
+      //     }
+      //     if (ele.data('type') == 0 && (numcs == 2 || numfc == 1)) {
+      //       return true;
+      //     } else if (ele.data('type') == 4 && (numcs == 1 || numfc == 2)) {
+      //       return true;
+      //     }
+      //     return false;
+      //   })
+      //   .addClass('evenNonGjWhenOddNonGjWithOutGj')
+      //   .style('curve-style', 'bezier')
+      //   .style('control-point-step-size', '40px');
+
+      // When there are an odd number of nonGj lines neighboring a gap junction, assign the oddNonGjWhenOddNonGjWithGj selector to the odd type
       cy.edges('[type = 2]')
         .parallelEdges()
+        .not(':loop')
         .filter('[type != 2]')
-        .filter('[type != 4]')
-        .removeClass('besideNeighbors')
-        .addClass('besideGjAlone');
+        .filter(function(ele) {
+          let numfc = 0;
+          let numcs = 0;
+          let nbrs = ele.parallelEdges()
+          for (let i = 0; i < nbrs.size(); i++) {
+            if (nbrs[i].data('type') === 0) {
+              numcs += 1;
+            } else if (nbrs[i].data('type') === 4) {
+              numfc += 1;
+            }
+          }
+          if (ele.data('type') == 4 && (numcs == 2 && numfc == 1)) {
+            console.log("odd functional connection num synapses:", numcs,"source: ", ele.source(), "target:", ele.target(), "edge:", ele)
+            return true;
+          } else if (ele.data('type') == 0 && (numcs == 1 && numfc == 2)) {
+            console.log("odd synapse")
+            return true;
+          }
+          return false;
+        })
+        .addClass('oddNonGjWhenOddNonGjWithGj')
+
+      // This is a fix for the fact that there are multiple edges going in 1 direction
+      // cy.edges('[type = 2]')
+      //   .parallelEdges()
+      //   .not(':loop')
+      //   .filter(function(ele, i, eles) {
+      //     let fcfwd = false;
+      //     let fcrev = false;
+      //     let csfwd = false;
+      //     let csrev = false;
+      //     var src = ele.data('source')
+      //     for (let i = 0; i < eles.size(); i++) {
+      //       if (eles[i].data('type') === 0) {
+      //         if (eles[i].data('source') === src) {
+      //           csfwd = true;
+      //         } else {
+      //           csrev = true;
+      //         }
+      //       } else if (eles[i].data('type') === 4) {
+      //         if (eles[i].data('source') === src) {
+      //           fcfwd = true;
+      //         } else {
+      //           fcrev = true;
+      //         }
+      //       }
+      //     }
+      //     if (ele.data('type') == 4 && ((csfwd && csrev) && ((fcfwd && !fcrev) || (!fcfwd && fcrev)))) {
+      //       console.log("odd functional connection num synapses:", numcs,"source: ", ele.source(), "target:", ele.target(), "edge:", ele)
+      //       return true;
+      //     } else if (ele.data('type') == 0 && ((fcfwd && fcrev) && ((csfwd && !csrev) || (!csfwd && csrev)))) {
+      //       console.log("odd synapse")
+      //       return true;
+      //     }
+      //     return false;
+      //   })
+      //   .addClass('oddNonGjWhenOddNonGjWithGj')
+
+      //   .style('curve-style', 'unbundled-bezier')
+      //   .style('control-point-step-size', '50px');
+
+      // When there are an odd number of nonGj lines not neighboring a gap junction, assign the oddNonGjWhenOddNonGjWithOutGj selector to the odd type
+      // cy.edges('[type != 2]')
+      // .parallelEdges()
+      // .filter(function(ele, i, eles) {
+      //   let eventype = '0';
+      //   let numfc = 0;
+      //   let numcs = 0;
+      //   for (let i = 0; i < eles.size; i++) {
+      //     if (eles[i].data('type') === 0) {
+      //       numcs += 1;
+      //     } else if (eles[i].data('type') === 4) {
+      //       numfc += 1;
+      //     }
+      //   }
+      //   if (ele.data('type') == 4 && (numcs == 2 || numfc == 1)) {
+      //     return true;
+      //   } else if (ele.data('type') == 0 && (numcs == 1 || numfc == 2)) {
+      //     return true;
+      //   }
+      //   return false;
+      // })
+      // .addClass('oddNonGjWhenOddNonGjWithOutGj')
+      // .style('curve-style', 'bezier')
+      // .style('control-point-step-size', '50px');
+
+      // let all3 = cy.edges('[type = 2]')
+      //   .parallelEdges()
+      //   .not(':loop')
+      //   .filter(function(ele, i, eles) {
+      //     let eventype = '0';
+      //     let numfc = 0;
+      //     let numcs = 0;
+      //     for (let i = 0; i < eles.size(); i++) {
+      //       if (eles[i].data('type') === 0) {
+      //         numcs += 1;
+      //       } else if (eles[i].data('type') === 4) {
+      //         numfc += 1;
+      //       }
+      //     }
+      //     if (ele.data('type') == 0 && (numcs == 2 || numfc == 1)) {
+      //       console.log("even synapse source: ", ele.source(), "target:", ele.target())
+      //       return true;
+      //     } else if (ele.data('type') == 4 && (numcs == 1 || numfc == 2)) {
+      //       console.log("even functional connection source: ", ele.source(), "target:", ele.target())
+      //       return true;
+      //     }
+      //     return false;
+      //   })
+      // console.log(all3.length)
 
       // Label nodes connected with gap junctions in order to efficiently update gap junction edges
       // that are stretched/shrinked as the node moves.

--- a/src/client/js/view/network.js
+++ b/src/client/js/view/network.js
@@ -184,12 +184,33 @@ class GraphView extends View2 {
       cy.add(Object.values(newEdges));
 
       cy.startBatch();
+      //
       // Label edges parallel to gap junctions to prevent overlaps.
-      cy.edges().removeClass('besideGj');
+      //
+
+      // Remove all bowing (dynamic: besideNeighbors and static: besideGjAlone)
+      cy.edges().removeClass('besideNeighbors');
+      cy.edges().removeClass('besideGjAlone');
+      // Start out by assuming every line has a neighbor (and dynamically & concentrically bow everything)
+      cy.edges().addClass('besideNeighbors');
+      // Remove bowing from all gap junctions
+      cy.edges('[type = 2]').removeClass('besideNeighbors');
+      // Get gap junctions that have a neighbor of 1 type (functional connections) and remove the bezier bowing and add
+      // a static bowing (unbundled-bezier)
       cy.edges('[type = 2]')
         .parallelEdges()
         .filter('[type != 2]')
-        .addClass('besideGj');
+        .filter('[type != 0]')
+        .removeClass('besideNeighbors')
+        .addClass('besideGjAlone');
+      // Get gap junctions that have a neighbor of 1 type (chemical synapse) and remove the bezier bowing and add a
+      // static bowing (unbundled-bezier)
+      cy.edges('[type = 2]')
+        .parallelEdges()
+        .filter('[type != 2]')
+        .filter('[type != 4]')
+        .removeClass('besideNeighbors')
+        .addClass('besideGjAlone');
 
       // Label nodes connected with gap junctions in order to efficiently update gap junction edges
       // that are stretched/shrinked as the node moves.

--- a/src/client/scss/icons.scss
+++ b/src/client/scss/icons.scss
@@ -65,7 +65,7 @@
   content: '\f0ca';
 }
 .icon-functional::before {
-  content: '\e5c4';
+  content: '\f178';
 }
 
 /* Popup menu */


### PR DESCRIPTION
**THIS WAS MERGED INTO `signed_arrowhead`, so this should be closed after the description has been read.**

Resolves issue #42

Note that the step sizes set in the bezier edges may not be necessary or match the unbundled-bezier control-point-distances.  I was just happy to get 2 tiers of bowing working.

Unbundled-bezier is used in 2 classes (one for each tier of bowing) is used when a gap junction is present to prevent overlap.

Note that each tier is meant to contain 1 connection type where feasible.  Default in the full case is synapses on the inner tier and funcons in the outer.

Ostensibly, this should have been able to work with a single class with 4 control-point-distances in a string (without the ability to control which types occur in which tiers), but every time I tried that, there was only 1 tier of bowing and overlap would occur.

Please see if you notice a difference in speed or if bowing looks different with & without gap junctions present.  Also not that without gap junctions, everything is controlled by bezier, as it was originally.

Also - I did not endeavor to silence impossible-to-draw warnings.  At various points during my working, they would go away and then come back.  I believe they have to do with lines overlapping in the initial attempt to draw and that it falls back to a "parent method" (my hypothesis).