### PR TITLE
Removed help links

### DIFF
--- a/src/client/webpack-template.index.html
+++ b/src/client/webpack-template.index.html
@@ -25,7 +25,9 @@
     <div id="searchbar" class="ui-widget" >
       <div id="open-settings"><i class="icon-cog"></i></div>
       <input type="text" />
-      <div id="show-help"><i class="icon-question"></i></div>
+      <!--
+        <div id="show-help"><i class="icon-question"></i></div>
+      -->
       <div id="loading-wheel"></div>
     </div>
 
@@ -51,10 +53,12 @@
         <div>
           <!-- Templates used in the settings -->
           <div id="dataset-bookmark-template" class="bookmark">
+            <!--
             <div class="dataset-tooltip">
               <h1> <small><i class="icon-question-circle-o smallhelp" data-topic="data-sources"></i></small></h1>
               <p></p>
             </div>
+            -->
             <div class="mark">
               <div class="rectangle"><div></div></div>
               <div class="triangle"><div></div></div>
@@ -63,7 +67,11 @@
 
           <!-- Databases and datasets -->
           <div class="group">
-            <h1>Dataset <small><i class="icon-question-circle-o smallhelp" data-topic="data-sources"></i></small></h1>
+            <h1>Dataset
+              <!--
+                <small><i class="icon-question-circle-o smallhelp" data-topic="data-sources"></i></small>
+              -->
+            </h1>
             <div id="set-database" class="selectbox">
               <div class="sel-placeholder"></div>
               <div class="option-container">


### PR DESCRIPTION
Note that the help links associated with "types of connections" were commented in #74.

#68

#68 references the replacement of tour with a welcome page, but that's a separate issue and this does not address that.