### PR TITLE
Welcome page update-- still need to dismiss on close and show only once.

### DIFF
--- a/src/client/js/controller/index.js
+++ b/src/client/js/controller/index.js
@@ -303,10 +303,10 @@ let bindHelpEvents = ({ view, controller }) => {
   let welcome = new Welcome(view, controller);
   let tour = new Tour(view, controller);
 
-  let hideImmatureTour = () =>
-    tour.isRunning() && tour.atFirstStep() ? tour.stop() : null;
+  // let hideImmatureTour = () =>
+  //   tour.isRunning() && tour.atFirstStep() ? tour.stop() : null;
   
-  let showImmatureTour = () => (tour.atFirstStep() ? tour.start() : null);
+  // let showImmatureTour = () => (tour.atFirstStep() ? tour.start() : null);
 
   let hideWelcome = () => welcome.isRunning() ? welcome.stop() : null;
   let showWelcome = () => welcome.isRunning() ? null : welcome.start();

--- a/src/client/js/controller/index.js
+++ b/src/client/js/controller/index.js
@@ -2,6 +2,7 @@ const { intersection } = require('../util');
 
 const EventEmitter = require('../EventEmitter');
 const Tour = require('./tour');
+const Welcome = require('./welcome');
 
 const DataService = require('../data-service');
 
@@ -299,11 +300,16 @@ let bindPopupMenuEvents = ({ model, view }) => {
 };
 
 let bindHelpEvents = ({ view, controller }) => {
+  let welcome = new Welcome(view, controller);
   let tour = new Tour(view, controller);
 
   let hideImmatureTour = () =>
     tour.isRunning() && tour.atFirstStep() ? tour.stop() : null;
+  
   let showImmatureTour = () => (tour.atFirstStep() ? tour.start() : null);
+
+  let hideWelcome = () => welcome.isRunning() ? welcome.stop() : null;
+  let showWelcome = () => welcome.isRunning() ? null : welcome.start();
 
   view.help
     .on('startTour', function() {
@@ -317,14 +323,30 @@ let bindHelpEvents = ({ view, controller }) => {
     })
     .on('nextTourStep', function() {
       tour.nextStep();
+    })
+    .on('startWelcome', function() {
+      view.help.hide();
+      controller.hideOpenUI();
+      welcome.start();
+    })
+    .on('endWelcome', function() {
+      controller.hideOpenUI();
+      welcome.end();
     });
 
   view.searchbar.on('inputChanged focusin', inputs => {
-    inputs.length === 0 ? showImmatureTour() : hideImmatureTour();
+    inputs.length === 0 ? showWelcome() : hideWelcome();
   });
+    
+  view.options.on('openSettings', () => hideWelcome());
+  view.graph.on('backgroundClick', () => hideWelcome());
+  
+  // view.searchbar.on('inputChanged focusin', inputs => {
+  //   inputs.length === 0 ? showImmatureTour() : hideImmatureTour();
+  // });
 
-  view.options.on('openSettings', () => hideImmatureTour());
-  view.graph.on('backgroundClick', () => hideImmatureTour());
+  // view.options.on('openSettings', () => hideImmatureTour());
+  // view.graph.on('backgroundClick', () => hideImmatureTour());
 };
 
 let bindHiddenEvents = ({ view, model }) => {

--- a/src/client/js/controller/index.js
+++ b/src/client/js/controller/index.js
@@ -309,7 +309,7 @@ let bindHelpEvents = ({ view, controller }) => {
   // let showImmatureTour = () => (tour.atFirstStep() ? tour.start() : null);
 
   let hideWelcome = () => welcome.isRunning() ? welcome.stop() : null;
-  let showWelcome = () => welcome.isRunning() ? null : welcome.start();
+  let showWelcome = () => welcome.isRunning() ? null : !welcome.wasDismissed() && welcome.start();
 
   view.help
     .on('startTour', function() {

--- a/src/client/js/controller/welcome.js
+++ b/src/client/js/controller/welcome.js
@@ -6,10 +6,15 @@ class Welcome {
     this.controller = controller;
 
     this._isRunning;
+    this._wasDismissed = false;
   }
 
   isRunning() {
     return this._isRunning;
+  }
+
+  wasDismissed() {
+    return this._wasDismissed;
   }
 
   start() {
@@ -25,6 +30,7 @@ class Welcome {
 
   stop() {
     this._isRunning = false;
+    this._wasDismissed = true;
     this.view.help.hideWelcome();
     this.view.popup.toggleHighlight('split', false);
 

--- a/src/client/js/controller/welcome.js
+++ b/src/client/js/controller/welcome.js
@@ -63,7 +63,7 @@ class Welcome {
         this.view.help.setWelcomeContent(
           'FunCoNN (Beta)',
           [
-            '<b>Welcome to FuNCoNN (Beta): Functional Connectivity on NemaNode</b>',
+            '<b>Welcome to FunCoNN (Beta): Functional Connectivity on NemaNode</b>',
             '<p>',
             'This is an interactive browser of functional connectivity measurements of',
             '<i>C. elegans</i> overlaid on select connectomics data using the software package',

--- a/src/client/js/controller/welcome.js
+++ b/src/client/js/controller/welcome.js
@@ -1,0 +1,93 @@
+const $ = require('jquery');
+
+class Welcome {
+  constructor(view, controller) {
+    this.view = view;
+    this.controller = controller;
+
+    this._isRunning;
+  }
+
+  isRunning() {
+    return this._isRunning;
+  }
+
+  start() {
+    this._isRunning = true;
+    this.view.graph.disableAnimations();
+
+    this.run();
+  }
+
+  end() {
+    this.stop();
+  }
+
+  stop() {
+    this._isRunning = false;
+    this.view.help.hideWelcome();
+    this.view.popup.toggleHighlight('split', false);
+
+    if (!this.view.graph.isSmallScreen()) {
+      this.view.graph.enableAnimations();
+    }
+    this.view.graph.removeSelection();
+  }
+
+  coordinate() {
+    let { x1, y2 } = this.view.searchbar.getBoundingBox();
+
+    return { x: x1 + 16 + 35, y: y2 };
+  }
+
+  position() {
+    return 'below-right';
+  }
+
+  run() {
+      
+    (() => {
+      let d = $.Deferred();
+
+      d.resolve();
+      return d;
+    })()
+      .then(() => {
+        // Update and display welcome.
+        this.view.help.setWelcomeContent(
+          'FunCoNN (Beta)',
+          [
+            '<b>Welcome to FuNCoNN (Beta): Functional Connectivity on NemaNode</b>',
+            '<p>',
+            'This is an interactive browser of functional connectivity measurements of',
+            '<i>C. elegans</i> overlaid on select connectomics data using the software package',
+            '<b>NemaNode</b>.',
+            '<p>',
+            'Functional connectivity measurements show the casual direction of information',
+            'flow, polarity and functional strength of neural connections based on',
+            'optogenetic perturbations and calcium imaging.',
+            '<p>',
+            'Functional measurements shown in this visualization are from a forthcoming',
+            '(in prep) manuscript from the Leifer Lab:',
+            '<p>',
+            'Randi, Dvali, Sharma & Leifer, <i>Direct Measurements of Functional Connectivity.</i>',
+            '<p>',
+            'Only those measured connections with a q-value less than 0.05 are shown.',
+            '<p>',
+            'Measurements are displayed using <b>NemaNode</b> (<i>nemanode.org</i>), an open',
+            'source software package described in <i>Witvleit et al., 2021</i> from the',
+            'Zhen, Samuel and Licthman labs. Select connectomics datasets from',
+            '<i>Witvleit et al</i>, and others, are also displayed.',
+            '<p>',
+            'This project is in beta and has not yet been peer reviewed.',
+            '<p>',
+            'Data and code are released under a permissive license at',
+            '<i>https://github.com/PrincetonUniversity/neuron-graph</i>'
+          ]
+        );
+        this.view.help.showWelcome(this.coordinate(), this.position());
+      });
+  }
+}
+
+module.exports = Welcome;

--- a/src/client/js/view/help.js
+++ b/src/client/js/view/help.js
@@ -22,6 +22,10 @@ class HelpView extends BaseView {
     this.$tourButtonDone = this.$tour.find('.done');
     this.$tourProgress = this.$tour.find('.progress');
 
+    this.$welcome = $('#welcome');
+    this.$welcomeTitle = this.$welcome.find('h1');
+    this.$welcomeBody = this.$welcome.find('.body');
+
     this.mouseOutsideBody = false;
     this.lastPositionLeft = 0;
     this.lastPositionTop = 0;
@@ -57,6 +61,10 @@ class HelpView extends BaseView {
       this.emit('nextTourStep');
       e.stopPropagation(); //prevent bubbling to inactive select boxes.
     });
+
+    $('#show-welcome').on('click', () => this.emit('startWelcome'));
+
+    $('#welcome .close #welcome .done').on('click', () => this.emit('endWelcome'));
 
     this.$arrowBack.click(() => this.showMenu());
 
@@ -259,6 +267,63 @@ class HelpView extends BaseView {
   hideTour() {
     this.$tour.hide();
   }
+
+  setWelcomeContent(title, body) {
+    this.$welcomeTitle.text(title);
+    this.$welcomeBody.html('<p>' + body.join('</p><p>') + '</p>');
+  }
+
+  showWelcome(coordinate, position) {
+    let { $welcome } = this;
+
+    const arrowWidth = 20;
+    const distanceToArrow = 35;
+    let containerWidth = $welcome.width();
+    //let containerHeight = $welcome.height();
+
+    $welcome.hide();
+    // If vertical position is outside viewport, scroll the options sidebar.
+    let currentScroll = $('#settings').scrollTop();
+    let offset = coordinate.y - window.innerHeight;
+
+    if (coordinate.y < 0) {
+      $('#settings').animate(
+        { scrollTop: currentScroll + coordinate.y - 50 },
+        200
+      );
+      coordinate.y = 50;
+    }
+
+    if (offset > 0) {
+      $('#settings').animate(
+        { scrollTop: currentScroll + offset + distanceToArrow },
+        200
+      );
+      coordinate.y -= offset + distanceToArrow;
+    }
+
+    // If horizontal position is outside viewport, push it back in.
+    if (
+      coordinate.x + containerWidth > window.innerWidth &&
+      position.startsWith('right')
+    ) {
+      coordinate.x = window.innerWidth - containerWidth - arrowWidth;
+    }
+
+    // Set position.
+    if (position == 'below-right') {
+      $welcome.css('left', coordinate.x - distanceToArrow);
+      $welcome.css('top', coordinate.y + arrowWidth);
+    } else {
+      // should never reach here but could throw an error or something, someday
+    }
+    $welcome.fadeIn('fast');
+  }
+
+  hideWelcome() {
+    this.$welcome.hide();
+  }
+
 }
 
 module.exports = HelpView;

--- a/src/client/js/view/help.js
+++ b/src/client/js/view/help.js
@@ -62,9 +62,9 @@ class HelpView extends BaseView {
       e.stopPropagation(); //prevent bubbling to inactive select boxes.
     });
 
-    $('#show-welcome').on('click', () => this.emit('startWelcome'));
+    $('#show-welcome').click(() => this.emit('startWelcome'));
 
-    $('#welcome .close #welcome .done').on('click', () => this.emit('endWelcome'));
+    $('#welcome .close, #welcome .done').click(() => this.emit('endWelcome'));
 
     this.$arrowBack.click(() => this.showMenu());
 

--- a/src/client/scss/help.scss
+++ b/src/client/scss/help.scss
@@ -272,5 +272,32 @@
 
 }
 
+#welcome {
+  display: none;
+  background-color: $background;
+  position: absolute;
+  width: 560px;
+  color: $text-color;
+  z-index: 900;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  border-radius: 2px;
+
+  .close {
+    float: right;
+    cursor: pointer;
+    margin-top: 15px;
+    margin-right: 15px;
+  }
+  h1 {
+    padding: 15px 15px 15px 15px;
+    font-size: 18px;
+  }
+  p {
+    padding: 3px 15px 3px 15px;
+    font-size: 13px;
+    line-height: 18px;
+  }
+}
+
 
 

--- a/src/client/webpack-template.index.html
+++ b/src/client/webpack-template.index.html
@@ -295,6 +295,7 @@
         <div class="menu">
           <h3>Learn how to use FunCoNN (BETA)</h3>
           <ol>
+            <li id="show-welcome" class="icon-welcome">Welcome</li>
             <li id="take-a-tour" class="icon-walkthrough">Take a tour</li>
           </ol>
           <h3>Data info</h3>
@@ -475,6 +476,12 @@
       <button class="done">Done</button>
       <button class="next">Next tip</button>
       <div class="progress"></div>
+    </div>
+    <div id="welcome">
+      <i class="close icon-close"></i>
+      <h1></h1>
+      <div class="body"></div>
+    </div>
     </div>
     <div id="footer" style="display: none; color: gray; font-size: 12px; position: absolute; right: 2px; bottom: 2px;">
       Open in <a href="https://nemanode.org/" target="_blank">FuNCoNN (Beta)</a>


### PR DESCRIPTION
Announcing Welcome Page 0.9b-- without the ability to close! Yes, the X on the upper right does absolutely nothing!

[Update: the no-close and re-appear bugs have been fixed]

You can dismiss it by clicking on the background or typing something however. But wait, there's more...

It will reappear if your searchbox is empty! That's right, if you backspace after typing AIX, AIY or whatever, when the searchbox is back to being blank again, the Welcome Page is back again as well! Did you miss it?

Also, just noticed I reference "icon-welcome" in the final diff screen below, but never actually made/defined one of those.

<img width="738" alt="WelcomePage" src="https://user-images.githubusercontent.com/889603/179301323-834fa481-eab4-4649-9421-3371674543d2.png">
