### PR TITLE
Hid the missing icon

### DIFF
--- a/src/client/scss/icons.scss
+++ b/src/client/scss/icons.scss
@@ -66,12 +66,14 @@
 }
 .icon-functional::before {
   content: '\ea0b';
+  visibility: hidden;
 }
 .icon-functional-excitatory::before {
   content: '\f178';
 }
 .icon-functional-inhibitory::before {
   content: '\ea0b';
+  visibility: hidden;
 }
 
 /* Popup menu */


### PR DESCRIPTION
Honestly, this is a hack, but so was the code originally. If I knew CSS better (or even a little), I wouldn't have a reference to a missing magic icon at all.

Resolves #64